### PR TITLE
Update uri to use https. Http was deprecated by pipedrive

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 


### PR DESCRIPTION
http://blog.pipedrive.com/2015/04/deprecating-http-non-secure-api-access-from-may-11-2015/
